### PR TITLE
feat: add "Volar Language Service Plugin" features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Plug 'yaegassy/coc-volar-tools', {'do': 'yarn install --frozen-lockfile'}
 
 - `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors
 
+## Volar Language Service Plugin
+
+### prettier-html
+
+**volar.config.js**:
+
+`/PATH/TO` should be adjusted in your environment.
+
+```javascript
+module.exports = {
+  plugins: [
+    require("/PATH/TO/coc/extensions/node_modules/@yaegassy/coc-volar-tools/lib/plugins/prettier-html").default(),
+  ],
+};
+```
+
 ## License
 
 MIT

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 async function start(watch) {
   await require('esbuild').build({
-    entryPoints: ['src/index.ts'],
+    entryPoints: ['src/index.ts', 'src/plugins/prettier-html.ts'],
+    //entryPoints: ['src/index.ts'],
     bundle: true,
     watch,
     minify: process.env.NODE_ENV === 'production',
@@ -10,7 +11,8 @@ async function start(watch) {
     external: ['coc.nvim'],
     platform: 'node',
     target: 'node10.12',
-    outfile: 'lib/index.js',
+    //outfile: 'lib/index.js',
+    outdir: 'lib',
   });
 }
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -8,7 +8,7 @@ async function start(watch) {
     minify: process.env.NODE_ENV === 'production',
     sourcemap: process.env.NODE_ENV === 'development',
     mainFields: ['module', 'main'],
-    external: ['coc.nvim'],
+    external: ['coc.nvim', 'prettier'],
     platform: 'node',
     target: 'node10.12',
     //outfile: 'lib/index.js',

--- a/src/plugins/prettier-html.ts
+++ b/src/plugins/prettier-html.ts
@@ -1,0 +1,25 @@
+import type { EmbeddedLanguageServicePlugin } from '@volar/vue-language-service-types';
+import * as prettier from 'prettier';
+
+export default function (): EmbeddedLanguageServicePlugin {
+  return {
+    format(document, range, options) {
+      if (document.languageId !== 'html') return;
+      const formattedText = prettier.format(document.getText(), {
+        tabWidth: options.tabSize,
+        useTabs: !options.insertSpaces,
+        parser: document.languageId,
+      });
+      if (formattedText === document.getText()) return []; // return empty array instead of undefined to avoid progress to next plugin
+      return [
+        {
+          range: {
+            start: document.positionAt(0),
+            end: document.positionAt(document.getText().length),
+          },
+          newText: formattedText,
+        },
+      ];
+    },
+  };
+}


### PR DESCRIPTION
I added the "Volar Language Service Plugin" in `coc-volar-tools`. I tried to support `prettier-html`.

However, the package size becomes very, very large when including the prettier itself...

**package size:  2.6 MB, unpacked size: 15.0 MB**

```
$ npm pack --dry-run
npm notice
npm notice 📦  @yaegassy/coc-volar-tools@0.0.2
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 1.1kB  README.md
npm notice 1.2MB  lib/index.js
npm notice 13.8MB lib/plugins/prettier-html.js
npm notice 1.8kB  package.json
npm notice === Tarball Details ===
npm notice name:          @yaegassy/coc-volar-tools
npm notice version:       0.0.2
npm notice filename:      @yaegassy/coc-volar-tools-0.0.2.tgz
npm notice package size:  2.6 MB
npm notice unpacked size: 15.0 MB
npm notice shasum:        fedf880f4f27db9221451054d795fb66cfa2b7ba
npm notice integrity:     sha512-MCeHf2wFUqU88[...]uK2zUwAI9rmqQ==
npm notice total files:   5
npm notice
yaegassy-coc-volar-tools-0.0.2.tgz
```